### PR TITLE
add proxy support of chrome webdriver

### DIFF
--- a/kwaiagents/utils/selenium_utils.py
+++ b/kwaiagents/utils/selenium_utils.py
@@ -1,3 +1,5 @@
+import os
+
 from selenium import webdriver
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.common.by import By
@@ -37,6 +39,9 @@ def get_web_driver(selenium_web_browser):
         options.add_argument('--no-sandbox')
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--headless')
+        proxy = os.getenv("http_proxy")
+        if proxy:
+            options.add_argument(f'--proxy-server={proxy}')
         current_driver = webdriver.Chrome(options=options)
     return current_driver
 


### PR DESCRIPTION
你好,我本地运行是 .search.py 中通过 duckduckgo-search 总是会报错,会走到后续使用 selenium 查询的地方
但是后续 selenium 查询时没有设置代理配置的逻辑
我添加后本地运行成功


