### PR TITLE
add stop parameter for qwen model

### DIFF
--- a/kwaiagents/llms/clients.py
+++ b/kwaiagents/llms/clients.py
@@ -81,6 +81,7 @@ class FastChatClient(object):
             prompt = self.make_baichuan_prompt(query, system, history)
         elif "qwen" in self.model:
             prompt = self.make_qwen_prompt(query, system, history)
+            stop = "<|endoftext|>"
         else:
             prompt = self.make_prompt(query, system, history)
         data = {
@@ -89,7 +90,8 @@ class FastChatClient(object):
             "temperature": 0.1,
             "top_p": 0.75,
             "top_k": 40,
-            "max_tokens": 512
+            "max_tokens": 512,
+            "stop": stop,
         }
         resp = requests.post(url=url, json=data, headers=headers)
         response = resp.json() # Check the JSON Response Content documentation below

--- a/kwaiagents/llms/clients.py
+++ b/kwaiagents/llms/clients.py
@@ -79,11 +79,13 @@ class FastChatClient(object):
         headers = {"Content-Type": "application/json"}
         if "baichuan" in self.model:
             prompt = self.make_baichuan_prompt(query, system, history)
+            stop = None
         elif "qwen" in self.model:
             prompt = self.make_qwen_prompt(query, system, history)
             stop = "<|endoftext|>"
         else:
             prompt = self.make_prompt(query, system, history)
+            stop = None
         data = {
             "model": self.model,
             "prompt": prompt,


### PR DESCRIPTION
在使用 Qwen-7B-MAT 模型做推理后端时,发现推理请求经常在返回 task json 之后继续返回大量无意义的语料,查看文档发现可以通过设置 stop 为 <|endoftext|>  来停止推理

未设置 stop:
![301704247064_ pic](https://github.com/KwaiKEG/KwaiAgents/assets/15722456/cb96372e-c728-4353-a8bc-cb5e86cb67e2)

设置 stop:
![311704247097_ pic](https://github.com/KwaiKEG/KwaiAgents/assets/15722456/2ad1c668-6d31-4ae3-b881-e1101b20d28d)
