### PR TITLE
修复评估脚本(benchmark_eval.py)中的bug

### DIFF
--- a/benchmark/benchmark_eval.py
+++ b/benchmark/benchmark_eval.py
@@ -196,7 +196,10 @@ def calculate_rouge_l(system_generated_summary, reference_summary):
     reference_summary = ' '.join(mixed_tokenize(reference_summary))
     system_generated_summary = ' ' if system_generated_summary == '' else system_generated_summary
     reference_summary = ' ' if reference_summary == '' or reference_summary == '.' else reference_summary
-    scores = rouge.get_scores(system_generated_summary, reference_summary, avg=True)
+    try:
+        scores = rouge.get_scores(system_generated_summary, reference_summary, avg=True)
+    except:
+        return 0.
     return round(scores['rouge-l']['f'],5)
 
 
@@ -497,7 +500,7 @@ def conclusion_metrics(label_dict, predict_dict):
                 if type(predict) == dict:
                     predict = json.dumps(predict,ensure_ascii=False)
                 for label in label_response_list:
-                    rouge_res = rouge_score(label,predict)
+                    rouge_res = rouge_score(label['golden_result'],predict)
                     predict_pre_label_score.append(rouge_res)
             predict_pre_template_score.append(max(predict_pre_label_score))
 
@@ -525,7 +528,7 @@ def profile_metrics(label_dict, predict_dict):
             all_rouge.append(0)
         else:
             for label in label_response_list:
-                rouge_res = rouge_score(label,predict)
+                rouge_res = rouge_score(label['golden_result'],predict)
                 rouge_list.append(rouge_res)
             all_rouge.append(max(rouge_list))
     profile_avg_rouge = sum(all_rouge)/len(all_rouge)


### PR DESCRIPTION
首先非常感谢您的开源！

我在运行`benchmark_eval.py`脚本时，发现如下bug，并做了相应修复：
1. `rouge.get_scores(Hypothesis, Reference)`方法中，参数"Hypothesis"与"Reference"并不接受值仅为空格的字符串；

2. 评测集中`golden_result_list`变量为`List[Dict]`类型，例如：
```
[{'golden_result': '2023年9月29日'},
 {'golden_result': '今年的中秋节是在2023年9月29日。'},
 {'golden_result': '今年的中秋节是阳历2023年9月29日。'},
 {'golden_result': '今年的中秋节是2023年9月29日。'},
 {'golden_result': '根据已知信息，2023年的中秋节是阳历的9月29日。'}]
```
因此通过`rouge.get_scores(Hypothesis, Reference)`方法计算时，`Reference`应为`label['golden_result']`.

另外，我发现评估脚本中颠倒了`Hypothesis`与`Reference`的位置，但由于最终选取rouge的f值，故在此pr中并未修改。

最后非常期待训练集的开源！